### PR TITLE
Change how we send timeout to binder

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -11,7 +11,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name:  na-cordex-viz-cookbook-dev
-      binder_nb_timeout: 3600 # one hour run time
 
   link-check:
     if: ${{ github.repository_owner == 'ProjectPythia' }}

--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -12,7 +12,6 @@ jobs:
     uses: ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml@main
     with:
       environment_name:  na-cordex-viz-cookbook-dev
-      binder_nb_timeout: 3600 # one hour run time
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -8,5 +8,4 @@ jobs:
     with:
       environment_name:  na-cordex-viz-cookbook-dev
       artifact_name: book-zip-${{ github.event.number }}
-      binder_nb_timeout: 3600 # one hour run time
       # Other input options are possible, see ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ execute:
   # To execute notebooks via a binder instead, replace 'cache' with 'binder'
   execute_notebooks: binder
   # execute_notebooks: cache
-  timeout: 600
+  timeout: 3600  # this cookbook needs longer than default run time
   allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
We updated the cookbook actions to use the existing `timeout` field in the jupyterbook config file rather than setting a custom argument for binderbot builds.

This PR gets this repo up to date with this small refactor.