### PR TITLE
Remove jupyter_server version pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 # For Pythia cookbook-related builds
 - jupyter-book
 - jupyterlab
-- jupyter_serve
+- jupyter_server
 - pip
 - pip:
     - sphinx-pythia-theme

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 # For Pythia cookbook-related builds
 - jupyter-book
 - jupyterlab
-- jupyter_server<2
+- jupyter_serve
 - pip
 - pip:
     - sphinx-pythia-theme


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This cookbook is encountering [some build problems on the binder](https://github.com/ProjectPythia/na-cordex-viz-cookbook/actions/runs/5415633740/jobs/9844222612#step:17:390)

Removing this obsolete version pin might help.